### PR TITLE
Drop support for python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
   - "3.3"
   - "3.4"

--- a/setup.py
+++ b/setup.py
@@ -14,14 +14,14 @@ setup(
     author_email='zetahernandez@gmail.com',
     url='http://github.com/zetahernandez/facebook-python-sdk',
     packages=['facebook_sdk'],
-    install_requires=['requests >=0.8', 'six >= 1.6'],
+    install_requires=['requests >=0.8'],
     classifiers=[
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5'
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
 )

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,53 +1,6 @@
-import difflib
-import pprint
-from unittest import TestCase as UnitTestCase
-
 from facebook_sdk.client import FacebookClient
 from facebook_sdk.request import FacebookRequest, FacebookBatchRequest
 from facebook_sdk.response import FacebookResponse
-
-
-def safe_repr(obj, short=False):
-    """
-    Helper class to provide backport support for `assertIn` and `assertIsInstance`
-    for python 2.6
-    """
-    MAX_LENGTH = 80
-    try:
-        result = repr(obj)
-    except Exception:
-        result = object.__repr__(obj)
-    if not short or len(result) < MAX_LENGTH:
-        return result
-    return result[:MAX_LENGTH] + ' [truncated]...'
-
-
-class TestCase(UnitTestCase):
-    def assertIsInstance(self, obj, cls, msg=None):
-        """ backward compatibility python2.6 """
-        if not isinstance(obj, cls):
-            standardMsg = '%s is not an instance of %r' % (safe_repr(obj), cls)
-            self.fail(self._formatMessage(msg, standardMsg))
-
-    def assertDictEqual(self, d1, d2, msg=None):
-        """ backward compatibility python2.6 """
-        self.assertIsInstance(d1, dict, 'First argument is not a dictionary')
-        self.assertIsInstance(d2, dict, 'Second argument is not a dictionary')
-
-        if d1 != d2:
-            standardMsg = '%s != %s' % (safe_repr(d1, True), safe_repr(d2, True))
-            diff = ('\n' + '\n'.join(difflib.ndiff(
-                pprint.pformat(d1).splitlines(),
-                pprint.pformat(d2).splitlines())))
-            standardMsg = self._truncateMessage(standardMsg, diff)
-            self.fail(self._formatMessage(msg, standardMsg))
-
-    def assertIn(self, member, container, msg=None):
-        """ backward compatibility python2.6 """
-        if member not in container:
-            standardMsg = '%s not found in %s' % (safe_repr(member),
-                                                  safe_repr(container))
-            self.fail(self._formatMessage(msg, standardMsg))
 
 
 class FakeFacebookClient(FacebookClient):

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -1,9 +1,10 @@
 import datetime
+from unittest import TestCase
 
 from facebook_sdk import __VERSION__ as VERSION
 from facebook_sdk.authentication import AccessToken, OAuth2Client
 from facebook_sdk.facebook import FacebookApp
-from tests import TestCase, FakeOAuth2Client
+from tests import FakeOAuth2Client
 
 try:
     from urllib.parse import quote_plus

--- a/tests/test_facebook.py
+++ b/tests/test_facebook.py
@@ -1,4 +1,5 @@
 import os
+from unittest import TestCase
 
 from facebook_sdk.authentication import AccessToken, OAuth2Client
 from facebook_sdk.client import FacebookClient
@@ -6,7 +7,7 @@ from facebook_sdk.exceptions import FacebookSDKException
 from facebook_sdk.facebook import FacebookApp, Facebook
 from facebook_sdk.facebook_file import FacebookFile
 from facebook_sdk.response import FacebookResponse
-from tests import TestCase, FakeFacebookClient, FakeResponse
+from tests import FakeFacebookClient, FakeResponse
 
 
 class TestFacebook(TestCase):
@@ -30,26 +31,22 @@ class TestFacebook(TestCase):
         self.assertEqual(str(self.facebook.default_access_token), 'my_token')
 
     def test_initialize_required_app_id_config(self):
-        self.assertRaises(
-            FacebookSDKException,
-            Facebook,
-        )
+        with self.assertRaises(FacebookSDKException):
+            Facebook()
 
     def test_initialize_required_app_secret_config(self):
-        self.assertRaises(
-            FacebookSDKException,
-            Facebook,
-            app_id='123',
-        )
+        with self.assertRaises(FacebookSDKException):
+            Facebook(
+                app_id='123',
+            )
 
     def test_initialize_invalid_access_token(self):
-        self.assertRaises(
-            ValueError,
-            Facebook,
-            app_id='123',
-            app_secret='123',
-            default_access_token=12345,  # token int not supported
-        )
+        with self.assertRaises(ValueError):
+            Facebook(
+                app_id='123',
+                app_secret='123',
+                default_access_token=12345,
+            )
 
     def test_send_request(self):
         self.facebook.client = FakeFacebookClient(

--- a/tests/test_facebook_client.py
+++ b/tests/test_facebook_client.py
@@ -1,8 +1,10 @@
+from unittest import TestCase
+
 from facebook_sdk.constants import BASE_GRAPH_URL
 from facebook_sdk.exceptions import FacebookResponseException, FacebookSDKException
 from facebook_sdk.request import FacebookRequest, FacebookBatchRequest
 from facebook_sdk.response import FacebookResponse, FacebookBatchResponse
-from tests import TestCase, FakeFacebookClient, FakeResponse
+from tests import FakeFacebookClient, FakeResponse
 
 
 class TestFacebookClient(TestCase):
@@ -43,11 +45,8 @@ class TestFacebookClient(TestCase):
                 status_code=400,
                 content='{"error": {"code": 100}}'),
         )
-        self.assertRaises(
-            FacebookResponseException,
-            self.client.send_request,
-            self.request,
-        )
+        with self.assertRaises(FacebookResponseException):
+            self.client.send_request(self.request)
 
     def test_send_batch_request(self):
         self.client = FakeFacebookClient(
@@ -59,21 +58,19 @@ class TestFacebookClient(TestCase):
         self.assertIsInstance(response, FacebookBatchResponse)
 
     def test_send_empty_batch_request(self):
-        self.assertRaises(
-            FacebookSDKException,
-            self.client.send_batch_request,
-            batch_request=FacebookBatchRequest(
-                access_token='fake_token',
-            ),
-        )
+        with self.assertRaises(FacebookSDKException):
+            self.client.send_batch_request(
+                batch_request=FacebookBatchRequest(
+                    access_token='fake_token',
+                ),
+            )
 
     def test_send_over_limit_batch_request(self):
         requests = [self.request] * 51
-        self.assertRaises(
-            FacebookSDKException,
-            self.client.send_batch_request,
-            batch_request=FacebookBatchRequest(
-                access_token='fake_token',
-                requests=requests,
-            ),
-        )
+        with self.assertRaises(FacebookSDKException):
+            self.client.send_batch_request(
+                batch_request=FacebookBatchRequest(
+                    access_token='fake_token',
+                    requests=requests,
+                ),
+            )

--- a/tests/test_facebook_file.py
+++ b/tests/test_facebook_file.py
@@ -1,8 +1,8 @@
 import os
+from unittest import TestCase
 
 from facebook_sdk.exceptions import FacebookSDKException
 from facebook_sdk.facebook_file import FacebookFile
-from tests import TestCase
 
 
 class TestFacebookFile(TestCase):
@@ -24,8 +24,7 @@ class TestFacebookFile(TestCase):
         self.assertTrue(self.facebook_file.name, 'foo.txt')
 
     def test_file_does_not_exist(self):
-        self.assertRaises(
-            FacebookSDKException,
-            FacebookFile,
-            path='does_not_exist.path',
-        )
+        with self.assertRaises(FacebookSDKException):
+            FacebookFile(
+                path='does_not_exist.path',
+            )

--- a/tests/test_facebook_request.py
+++ b/tests/test_facebook_request.py
@@ -1,11 +1,11 @@
 import os
+from unittest import TestCase
 
 from facebook_sdk.constants import DEFAULT_GRAPH_VERSION, METHOD_POST, METHOD_GET, METHOD_DELETE
 from facebook_sdk.exceptions import FacebookSDKException
 from facebook_sdk.facebook_file import FacebookFile
 from facebook_sdk.request import FacebookBatchRequest, FacebookRequest
 from facebook_sdk.utils import force_slash_prefix
-from tests import TestCase
 
 
 class TestFacebookRequest(TestCase):
@@ -64,12 +64,11 @@ class TestFacebookRequest(TestCase):
         self.assertEqual(request.access_token, 'foo_token')
 
     def test_endpoint_with_distinct_access_tokens(self):
-        self.assertRaises(
-            FacebookSDKException,
-            FacebookRequest,
-            endpoint='/foo?access_token=foo_token',
-            access_token='bar_token',
-        )
+        with self.assertRaises(FacebookSDKException):
+            FacebookRequest(
+                endpoint='/foo?access_token=foo_token',
+                access_token='bar_token',
+            )
 
     def test_empty_endpoint_url(self):
         request = FacebookRequest(endpoint='')

--- a/tests/test_facebook_response.py
+++ b/tests/test_facebook_response.py
@@ -1,10 +1,11 @@
 import json
+from unittest import TestCase
 
 from facebook_sdk.constants import METHOD_GET, METHOD_POST
 from facebook_sdk.exceptions import FacebookResponseException, FacebookSDKException
 from facebook_sdk.request import FacebookRequest
 from facebook_sdk.response import FacebookResponse, FacebookBatchResponse
-from tests import FakeFacebookRequest, FakeFacebookBatchRequest, TestCase
+from tests import FakeFacebookRequest, FakeFacebookBatchRequest
 
 
 class TestFacebookResponse(TestCase):
@@ -24,10 +25,8 @@ class TestFacebookResponse(TestCase):
             http_status_code=200
         )
 
-        self.assertRaises(
-            FacebookResponseException,
-            response.raiseException,
-        )
+        with self.assertRaises(FacebookResponseException):
+            response.raiseException()
 
     def test_build_exception(self):
         response = FacebookResponse(
@@ -96,10 +95,8 @@ class TestFacebookResponsePagination(TestCase):
     def test_http_allowed_method_for_pagination(self):
         self.response.request.method = 'POST'
 
-        self.assertRaises(
-            FacebookSDKException,
-            self.response.next_page_request,
-        )
+        with self.assertRaises(FacebookSDKException):
+            self.response.next_page_request()
 
 
 class TestFacebookBatchResponse(TestCase):


### PR DESCRIPTION
Drop support to python 2.6 since it was officially retired in October 2013. https://www.python.org/download/releases/2.6.9/