### PR TITLE
Support to override request timeout

### DIFF
--- a/facebook_sdk/client.py
+++ b/facebook_sdk/client.py
@@ -5,10 +5,14 @@ except ImportError:
 import requests
 
 from facebook_sdk.constants import BASE_GRAPH_URL, DEFAULT_REQUEST_TIMEOUT
-from facebook_sdk.response import FacebookResponse, FacebookBatchResponse
+from facebook_sdk.response import FacebookBatchResponse, FacebookResponse
 
 
 class FacebookClient(object):
+
+    def __init__(self, request_timeout=None):
+        self.timeout = request_timeout or DEFAULT_REQUEST_TIMEOUT
+
     def _prepareRequest(self, request):
         """
 
@@ -36,7 +40,7 @@ class FacebookClient(object):
             data=data,
             headers=request.headers,
             files=request.files_to_upload(),
-            timeout=DEFAULT_REQUEST_TIMEOUT,
+            timeout=self.timeout,
         )
 
     def send_request(self, request):
@@ -62,9 +66,6 @@ class FacebookClient(object):
         return response
 
     def send(self, data, headers, method, params, url, files, timeout):
-        # TODO: Refactor this to support multiple client managers
-        # like requests, curl, urllib, etc...
-
         response = requests.request(
             method=method,
             url=url,

--- a/facebook_sdk/facebook.py
+++ b/facebook_sdk/facebook.py
@@ -35,7 +35,7 @@ class FacebookApp(object):
 
 
 class Facebook(object):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, **kwargs):
         super(Facebook, self).__init__()
 
         self.config = {
@@ -69,7 +69,7 @@ class Facebook(object):
             app_id=self.config['app_id'],
             app_secret=self.config['app_secret']
         )
-        self.client = FacebookClient()
+        self.client = FacebookClient(request_timeout=kwargs.get('default_request_timeout'))
         self.oauth_client = OAuth2Client(
             app=self.app,
             client=self.client,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -4,11 +4,13 @@ from facebook_sdk.response import FacebookResponse
 
 
 class FakeFacebookClient(FacebookClient):
-    def __init__(self, fake_response):
-        super(FakeFacebookClient, self).__init__()
-        self.fake_response = fake_response
+    def __init__(self, **kwargs):
+        self.fake_response = kwargs.pop('fake_response')
+        super(FakeFacebookClient, self).__init__(**kwargs)
 
     def send(self, *args, **kwargs):
+        self.send_args = args,
+        self.send_kwargs = kwargs
         return self.fake_response
 
 

--- a/tests/test_facebook.py
+++ b/tests/test_facebook.py
@@ -18,6 +18,7 @@ class TestFacebook(TestCase):
             app_secret='secret',
             default_access_token='my_token',
             default_graph_version='v2.6',
+            default_request_timeout=10,
         )
 
     def test_initialize(self):
@@ -29,6 +30,7 @@ class TestFacebook(TestCase):
         self.assertEqual(self.facebook.app.secret, 'secret')
         self.assertEqual(self.facebook.default_graph_version, 'v2.6')
         self.assertEqual(str(self.facebook.default_access_token), 'my_token')
+        self.assertEqual(self.facebook.client.timeout, 10)
 
     def test_initialize_required_app_id_config(self):
         with self.assertRaises(FacebookSDKException):


### PR DESCRIPTION
Support to override the default request timeout 
```
facebook = Facebook(
    'app_id': '1234',
    'app_secret': 'my_secret',
    'default_request_timeout': 10,
)
```