### PR TITLE
Add a per request timeout setting

### DIFF
--- a/facebook_sdk/client.py
+++ b/facebook_sdk/client.py
@@ -28,7 +28,7 @@ class FacebookClient(object):
                 data = request.post_params
         else:
             request.add_headers([
-                {'Content-Type': 'application/x-www-form-urlencoded'}
+                {'Content-Type': 'application/x-www-form-urlencoded'},
             ])
             if request.post_params:
                 data = urlencode(request.post_params)
@@ -40,7 +40,7 @@ class FacebookClient(object):
             data=data,
             headers=request.headers,
             files=request.files_to_upload(),
-            timeout=self.timeout,
+            timeout=request.timeout or self.timeout,
         )
 
     def send_request(self, request):
@@ -57,7 +57,7 @@ class FacebookClient(object):
         response = FacebookResponse(
             request=request,
             body=res.content,
-            http_status_code=res.status_code
+            http_status_code=res.status_code,
         )
 
         if response.is_error:
@@ -89,7 +89,7 @@ class FacebookClient(object):
 
         response = FacebookBatchResponse(
             batch_request=batch_request,
-            batch_response=batch_response
+            batch_response=batch_response,
         )
 
         return response

--- a/facebook_sdk/facebook.py
+++ b/facebook_sdk/facebook.py
@@ -29,8 +29,8 @@ class FacebookApp(object):
         return AccessToken(
             access_token='{id}|{secret}'.format(
                 id=self.id,
-                secret=self.secret
-            )
+                secret=self.secret,
+            ),
         )
 
 
@@ -76,7 +76,7 @@ class Facebook(object):
             graph_version=self.default_graph_version,
         )
 
-    def request(self, method, endpoint, access_token=None, params=None, headers=None, graph_version=None):
+    def request(self, method, endpoint, access_token=None, params=None, headers=None, graph_version=None, timeout=None):
         access_token = access_token or getattr(self, 'default_access_token', None)
         graph_version = graph_version or self.default_graph_version
 
@@ -88,9 +88,10 @@ class Facebook(object):
             params=params,
             headers=headers,
             graph_version=graph_version,
+            timeout=timeout,
         )
 
-    def send_request(self, method, endpoint, access_token=None, params=None, headers=None, graph_version=None):
+    def send_request(self, method, endpoint, access_token=None, params=None, headers=None, graph_version=None, timeout=None):
         request = self.request(
             method=method,
             access_token=access_token,
@@ -98,6 +99,7 @@ class Facebook(object):
             params=params,
             headers=headers,
             graph_version=graph_version,
+            timeout=timeout,
         )
         response = self.send_facebook_request(request=request)
 
@@ -109,7 +111,7 @@ class Facebook(object):
         """
         return self.client.send_request(request=request)
 
-    def send_batch_request(self, requests, access_token=None, graph_version=None):
+    def send_batch_request(self, requests, access_token=None, graph_version=None, timeout=None):
         access_token = access_token or getattr(self, 'default_access_token', None)
         graph_version = graph_version or self.default_graph_version
 
@@ -118,6 +120,7 @@ class Facebook(object):
             requests=requests,
             access_token=access_token,
             graph_version=graph_version,
+            timeout=timeout,
         )
 
         response = self.client.send_batch_request(batch_request=batch_request)

--- a/facebook_sdk/request.py
+++ b/facebook_sdk/request.py
@@ -2,6 +2,7 @@ import uuid
 
 from facebook_sdk.facebook_file import FacebookFile
 
+
 try:
     import simplejson as json
 except ImportError:
@@ -30,7 +31,7 @@ class FacebookRequest(object):
     """
 
     def __init__(self, app=None, access_token=None, method=None, endpoint=None, params=None, headers=None,
-                 graph_version=None):
+                 graph_version=None, timeout=None):
         super(FacebookRequest, self).__init__()
 
         # Default empty dicts for dict params.
@@ -45,6 +46,7 @@ class FacebookRequest(object):
         self.graph_version = graph_version
         self.headers = headers
         self.params = params
+        self.timeout = timeout
 
     @property
     def endpoint(self):
@@ -175,7 +177,7 @@ class FacebookBatchRequest(FacebookRequest):
 
     """
 
-    def __init__(self, app=None, requests=None, access_token=None, graph_version=None):
+    def __init__(self, app=None, requests=None, access_token=None, graph_version=None, timeout=None):
         """
         :param requests: a list of FacebookRequest
         :param access_token: the access token for the batch request
@@ -189,6 +191,7 @@ class FacebookBatchRequest(FacebookRequest):
             graph_version=graph_version,
             method=METHOD_POST,
             endpoint='',
+            timeout=timeout,
         )
 
         self.requests = []

--- a/tests/test_facebook.py
+++ b/tests/test_facebook.py
@@ -55,7 +55,7 @@ class TestFacebook(TestCase):
             fake_response=FakeResponse(
                 status_code=200,
                 content='',
-            )
+            ),
         )
         response = self.facebook.send_request(
             method='GET',
@@ -72,7 +72,7 @@ class TestFacebook(TestCase):
         self.assertEqual(response.request.timeout, 182)
         self.assertDictEqual(response.request.params, {'access_token': 'foo_token'})
 
-    def test_send_request_default_access_token___version_and_timeout(self):
+    def test_send_request_default_access_token_and_version(self):
         self.facebook.client = FakeFacebookClient(
             fake_response=FakeResponse(
                 status_code=200,
@@ -88,7 +88,6 @@ class TestFacebook(TestCase):
         self.assertEqual(response.request.endpoint, 'some_endpoint')
         self.assertEqual(response.request.access_token, 'my_token')
         self.assertEqual(response.request.graph_version, 'v2.6')
-        self.assertEqual(response.request.timeout, 10)
         self.assertDictEqual(response.request.params, {'access_token': 'my_token'})
 
     def test_send_batch_request(self):
@@ -116,7 +115,7 @@ class TestFacebook(TestCase):
         self.assertEqual(response.request.timeout, 182)
         self.assertDictEqual(response.request.params, {'access_token': 'foo_token'})
 
-    def test_send_batch_request_default_access_token__version_and_timeout(self):
+    def test_send_batch_request_default_access_token_and_version(self):
         self.facebook.client = FakeFacebookClient(
             fake_response=FakeResponse(
                 status_code=200,
@@ -135,7 +134,6 @@ class TestFacebook(TestCase):
         self.assertEqual(response.request.method, 'POST')
         self.assertEqual(response.request.access_token, 'my_token')
         self.assertEqual(response.request.graph_version, 'v2.6')
-        self.assertEqual(response.request.timeout, 60)
         self.assertDictEqual(response.request.params, {'access_token': 'my_token'})
 
     def test_get_facebook_get_method(self):

--- a/tests/test_facebook.py
+++ b/tests/test_facebook.py
@@ -61,16 +61,18 @@ class TestFacebook(TestCase):
             method='GET',
             endpoint='some_endpoint',
             access_token='foo_token',
-            graph_version='v2.7'
+            graph_version='v2.7',
+            timeout=182,
         )
         self.assertIsInstance(response, FacebookResponse)
         self.assertEqual(response.request.method, 'GET')
         self.assertEqual(response.request.endpoint, 'some_endpoint')
         self.assertEqual(response.request.access_token, 'foo_token')
         self.assertEqual(response.request.graph_version, 'v2.7')
+        self.assertEqual(response.request.timeout, 182)
         self.assertDictEqual(response.request.params, {'access_token': 'foo_token'})
 
-    def test_send_request_default_access_token_and_version(self):
+    def test_send_request_default_access_token___version_and_timeout(self):
         self.facebook.client = FakeFacebookClient(
             fake_response=FakeResponse(
                 status_code=200,
@@ -86,6 +88,7 @@ class TestFacebook(TestCase):
         self.assertEqual(response.request.endpoint, 'some_endpoint')
         self.assertEqual(response.request.access_token, 'my_token')
         self.assertEqual(response.request.graph_version, 'v2.6')
+        self.assertEqual(response.request.timeout, 10)
         self.assertDictEqual(response.request.params, {'access_token': 'my_token'})
 
     def test_send_batch_request(self):
@@ -103,15 +106,17 @@ class TestFacebook(TestCase):
         response = self.facebook.send_batch_request(
             requests=batches,
             access_token='foo_token',
-            graph_version='v2.7'
+            graph_version='v2.7',
+            timeout=182,
         )
 
         self.assertEqual(response.request.method, 'POST')
         self.assertEqual(response.request.access_token, 'foo_token')
         self.assertEqual(response.request.graph_version, 'v2.7')
+        self.assertEqual(response.request.timeout, 182)
         self.assertDictEqual(response.request.params, {'access_token': 'foo_token'})
 
-    def test_send_batch_request_default_access_token_and_version(self):
+    def test_send_batch_request_default_access_token__version_and_timeout(self):
         self.facebook.client = FakeFacebookClient(
             fake_response=FakeResponse(
                 status_code=200,
@@ -130,6 +135,7 @@ class TestFacebook(TestCase):
         self.assertEqual(response.request.method, 'POST')
         self.assertEqual(response.request.access_token, 'my_token')
         self.assertEqual(response.request.graph_version, 'v2.6')
+        self.assertEqual(response.request.timeout, 60)
         self.assertDictEqual(response.request.params, {'access_token': 'my_token'})
 
     def test_get_facebook_get_method(self):


### PR DESCRIPTION
Adds the ability to override the facebook_client default timeout with a more granular setting per request.

Ping @zetahernandez as discussed in person.
