### PR TITLE
Drop support for Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 
 python:
     - '2.7'
-    - '3.3'
     - '3.4'
     - '3.5'
     - '3.6'
@@ -13,7 +12,7 @@ install:
     - pip install -r requirements-dev.txt
 
 script:
-    - py.test --cov=facebook_sdk tests
+    - pytest --cov=facebook_sdk tests
 
 after_success:
     - coveralls

--- a/README.rst
+++ b/README.rst
@@ -114,4 +114,4 @@ Running tests
 .. code-block:: bash
 
  ➜  facebook-python-sdk $ pip install -r requirements-dev.txt
- ➜  facebook-python-sdk $ py.test
+ ➜  facebook-python-sdk $ pytest

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',


### PR DESCRIPTION
Python 3.3 was deprecated on September 29, 2017 [1].

[1] https://www.python.org/dev/peps/pep-0398/#x-end-of-life