### PR TITLE
Add support for bytestrings in FacebookResponse _parse_body

### DIFF
--- a/facebook_sdk/request.py
+++ b/facebook_sdk/request.py
@@ -1,20 +1,11 @@
+import json
 import uuid
 
-from facebook_sdk.facebook_file import FacebookFile
-
-
-try:
-    import simplejson as json
-except ImportError:
-    import json
-
-try:
-    from urllib.parse import urlencode
-except ImportError:
-    from urllib import urlencode
+from six.moves.urllib.parse import urlencode
 
 from facebook_sdk.constants import DEFAULT_GRAPH_VERSION, METHOD_POST
 from facebook_sdk.exceptions import FacebookSDKException
+from facebook_sdk.facebook_file import FacebookFile
 from facebook_sdk.utils import (
     convert_params_to_utf8,
     force_slash_prefix,

--- a/facebook_sdk/response.py
+++ b/facebook_sdk/response.py
@@ -1,15 +1,9 @@
 from copy import copy
+import json
 
 from facebook_sdk.constants import METHOD_GET
-from facebook_sdk.utils import base_graph_url_endpoint
-
-try:
-    import simplejson as json
-except ImportError:
-    import json
-
 from facebook_sdk.exceptions import FacebookResponseException, FacebookSDKException
-from facebook_sdk.request import FacebookRequest, FacebookBatchRequest
+from facebook_sdk.utils import base_graph_url_endpoint, smart_text
 
 
 class ResponsePaginationMixin(object):
@@ -77,8 +71,8 @@ class FacebookResponse(ResponsePaginationMixin):
 
         """
         try:
-            self.json_body = json.loads(self.body)
-        except:
+            self.json_body = json.loads(smart_text(self.body))
+        except Exception:
             self.json_body = {}
 
     def raiseException(self):

--- a/facebook_sdk/utils.py
+++ b/facebook_sdk/utils.py
@@ -43,3 +43,12 @@ def convert_params_to_utf8(params):
         k: v.encode("utf-8") if isinstance(v, six.text_type) else v
         for k, v in params.items()
     }
+
+
+def smart_text(value, encoding='utf-8', **kwargs):
+    if isinstance(value, six.text_type):
+        return value
+    elif isinstance(value, six.binary_type):
+        return value.decode(encoding=encoding, **kwargs)
+    else:
+        return six.text_type(value)

--- a/tests/test_facebook_response.py
+++ b/tests/test_facebook_response.py
@@ -18,6 +18,15 @@ class TestFacebookResponse(TestCase):
         )
         self.assertEqual(expected_body, response.json_body)
 
+    def test_parse_body_for_bytestrings(self):
+        expected_body = {'success': True}
+        response = FacebookResponse(
+            request=FakeFacebookRequest(),
+            body=b'{"success": true}',
+            http_status_code=200,
+        )
+        self.assertEqual(expected_body, response.json_body)
+
     def test_raise_exception(self):
         response = FacebookResponse(
             request=FakeFacebookRequest(),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+
+from unittest import TestCase
+
+from facebook_sdk.utils import smart_text
+
+
+class TestFacebookFile(TestCase):
+
+    def test_smart_text(self):
+        test_scenarios = (
+            (u'Beyoncé'.encode('utf-8'), u'Beyoncé'),
+            (u'Beyoncé', u'Beyoncé'),
+            (1, u'1'),
+        )
+        for value, expected in test_scenarios:
+            self.assertEqual(smart_text(value), expected)


### PR DESCRIPTION
The method `_parse_body` was failing in Python 3.4 and 3.5 [1], because of `json.loads` failing, as it can only receive unicode strings, until Python 3.6 [2].

This change also removes the usage of `simplejson`, for a standard interface to deal with, and implements a `smart_text` util to always provide unicode strings to `json.loads`.

[1] https://travis-ci.org/eventbrite/facebook-py-sdk/jobs/370625780
[2] https://docs.python.org/3/whatsnew/3.6.html#json