### PR TITLE
Remove version from requests requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-requests==2.11.1
+requests


### PR DESCRIPTION
Being a library, we shouldn't force other projects to use a particular version of the needed requirements, but only define bounds the project must meet. I don't know if we need a minumum version for `requests`, so just ask for it.