### PR TITLE
Add pip cache to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ python:
     - '3.5'
     - '3.6'
 
+cache: pip
+
 install:
     - pip install -U pip wheel
     - pip install -r requirements.txt


### PR DESCRIPTION
Speed up Travis builds and reduce traffic to pypi, by adding a pip
cache, as described in Travis docs [1].

[1] https://docs.travis-ci.com/user/caching/#pip-cache